### PR TITLE
Command Analytics

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   NewCops: enable
+  TargetRubyVersion: 2.5
 
 Layout/LineLength:
   Max: 120

--- a/lib/vtk/analytics.rb
+++ b/lib/vtk/analytics.rb
@@ -10,15 +10,16 @@ module Vtk
   class Analytics
     CLIENT_KEY = ''
 
-    attr_reader :args, :hostname
+    attr_reader :name, :args, :hostname
 
-    def initialize(name:, hostname: nil)
-      @args = name
+    def initialize(name:, args: nil, hostname: nil)
+      @name = name
+      @args = args || ARGV.join('_')
       @hostname = hostname || `hostname -f`.chomp
     end
 
     def log
-      return if ENV['CI'] || ENV['TEST']
+      return if ENV['CI'] || ENV['TEST'] || ENV['VTK_DISABLE_ANALYTICS']
 
       Process.fork do
         exit unless internet?
@@ -43,7 +44,7 @@ module Vtk
         metric: 'vtk.command_executed',
         type: 'count',
         interval: 1,
-        tags: "args:#{args}",
+        tags: ["name:#{name}", "args:#{args}"],
         host: hostname,
         points: [[Time.now.utc.to_i, '1']]
       }

--- a/lib/vtk/analytics.rb
+++ b/lib/vtk/analytics.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'net/http'
+require 'open-uri'
+require 'uri'
+
+module Vtk
+  # Provides command analytics to VTK team
+  class Analytics
+    CLIENT_KEY = ''
+
+    attr_reader :name, :title, :hostname
+
+    def initialize(name:, title:, hostname: nil)
+      @name = "vtk.#{name}"
+      @title = "VTK #{title}"
+      @hostname = hostname || `hostname -f`.chomp
+    end
+
+    def log
+      return if ENV['CI'] || ENV['TEST']
+
+      Process.fork do
+        begin
+          exit unless internet?
+
+          emit_event
+        rescue StandardError
+          false # Silently error
+        end
+      end
+    end
+
+    def emit_event
+      uri = URI.parse "https://api.datadoghq.com/api/v1/events?api_key=#{CLIENT_KEY}"
+      Net::HTTP.start uri.host, uri.port, use_ssl: true do |http|
+        request = Net::HTTP::Post.new uri, 'Content-Type' => 'application/json'
+        request.body = { title: title, text: name, date_happened: Time.now.utc.to_i, host: hostname }.to_json
+        http.request request
+      end
+    end
+
+    def internet?
+      true if URI.open 'http://www.google.com/'
+    rescue SocketError
+      false
+    end
+  end
+end

--- a/lib/vtk/analytics.rb
+++ b/lib/vtk/analytics.rb
@@ -10,11 +10,10 @@ module Vtk
   class Analytics
     CLIENT_KEY = ''
 
-    attr_reader :name, :title, :hostname
+    attr_reader :args, :hostname
 
-    def initialize(name:, title:, hostname: nil)
-      @name = "vtk.#{name}"
-      @title = "VTK #{title}"
+    def initialize(name:, hostname: nil)
+      @args = name
       @hostname = hostname || `hostname -f`.chomp
     end
 
@@ -24,19 +23,30 @@ module Vtk
       Process.fork do
         exit unless internet?
 
-        emit_event
+        emit_point
       rescue StandardError
         false # Silently error
       end
     end
 
-    def emit_event
-      uri = URI.parse "https://api.datadoghq.com/api/v1/events?api_key=#{CLIENT_KEY}"
+    def emit_point
+      uri = URI.parse "https://api.datadoghq.com/api/v1/series?api_key=#{CLIENT_KEY}"
       Net::HTTP.start uri.host, uri.port, use_ssl: true do |http|
         request = Net::HTTP::Post.new uri, 'Content-Type' => 'application/json'
-        request.body = { title: title, text: name, date_happened: Time.now.utc.to_i, host: hostname }.to_json
+        request.body = { series: [point] }.to_json
         http.request request
       end
+    end
+
+    def point
+      {
+        metric: 'vtk.command_executed',
+        type: 'count',
+        interval: 1,
+        tags: "args:#{args}",
+        host: hostname,
+        points: [[Time.now.utc.to_i, '1']]
+      }
     end
 
     def internet?

--- a/lib/vtk/analytics.rb
+++ b/lib/vtk/analytics.rb
@@ -22,13 +22,11 @@ module Vtk
       return if ENV['CI'] || ENV['TEST']
 
       Process.fork do
-        begin
-          exit unless internet?
+        exit unless internet?
 
-          emit_event
-        rescue StandardError
-          false # Silently error
-        end
+        emit_event
+      rescue StandardError
+        false # Silently error
       end
     end
 

--- a/lib/vtk/analytics.rb
+++ b/lib/vtk/analytics.rb
@@ -8,8 +8,6 @@ require 'uri'
 module Vtk
   # Provides command analytics to VTK team
   class Analytics
-    CLIENT_KEY = ''
-
     attr_reader :name, :args, :hostname
 
     def initialize(name:, args: nil, hostname: nil)
@@ -31,8 +29,8 @@ module Vtk
     end
 
     def emit_point
-      uri = URI.parse "https://api.datadoghq.com/api/v1/series?api_key=#{CLIENT_KEY}"
-      Net::HTTP.start uri.host, uri.port, use_ssl: true do |http|
+      uri = URI.parse 'https://dev.va.gov/_vfs/vtk-analytics/record'
+      Net::HTTP.start uri.host, uri.port, use_ssl: uri.scheme == 'https' do |http|
         request = Net::HTTP::Post.new uri, 'Content-Type' => 'application/json'
         request.body = { series: [point] }.to_json
         http.request request

--- a/lib/vtk/command.rb
+++ b/lib/vtk/command.rb
@@ -11,7 +11,8 @@ module Vtk
     def_delegators :command, :run
 
     def initialize
-      Vtk::Analytics.new(name: "command_called.#{ARGV.join '-'}", title: 'Command Called').log
+      command_name = self.class.to_s.split('::').last(2).join('_').downcase
+      Vtk::Analytics.new(name: command_name).log
     end
 
     # Execute this command

--- a/lib/vtk/command.rb
+++ b/lib/vtk/command.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'forwardable'
+require 'vtk/analytics'
 
 module Vtk
   # Command class that all command inherit from
@@ -8,6 +9,10 @@ module Vtk
     extend Forwardable
 
     def_delegators :command, :run
+
+    def initialize
+      Vtk::Analytics.new(name: "command_called.#{ARGV.join '-'}", title: 'Command Called').log
+    end
 
     # Execute this command
     #

--- a/lib/vtk/version.rb
+++ b/lib/vtk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Vtk
-  VERSION = '0.7.0'
+  VERSION = '0.8.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,8 @@
 
 require 'vtk'
 
+ENV['TEST'] ||= 'test'
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'

--- a/vtk.gemspec
+++ b/vtk.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'A CLI for the platform'
   spec.description   = 'This is a platform CLI tool for VFS developer usage.'
   spec.homepage      = 'https://github.com/department-of-veterans-affairs/vtk'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['documentation_uri'] = spec.homepage
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '~> 0.13.0'
   spec.add_development_dependency 'rake', '~> 13.0.0'
   spec.add_development_dependency 'rspec', '~> 3.10.0'
-  spec.add_development_dependency 'rubocop', '~> 1.6.0'
+  spec.add_development_dependency 'rubocop', '~> 1.8.0'
   spec.add_development_dependency 'rubocop-rake', '~> 0.5.0'
   spec.add_development_dependency 'rubocop-rspec', '~> 2.0.0'
 


### PR DESCRIPTION
Reports command usage to [data dog](https://app.datadoghq.com/dashboard/gv7-sg4-5tm/vtk-commands?from_ts=1611779330686&live=true&to_ts=1611782930686).

You can test this by checking out this branch and running `exe/vtk module add test`.

- The POST to data dog is forked so it doesn't block exiting of original command
- Analytics aren't collected if you're offline
- Non existent commands are not logged
- Reports to our [vtk cli-analytics middleware](https://github.com/department-of-veterans-affairs/cli-analytics)

TODO:

- [x] Add env var to prevent tracking; recommend all vtk devs to set it
- [ ] ~Get install count~ Data dog doesn't support this
- [ ] ~Track help command?~ This wasn't easily achievable.