### PR TITLE
Add ops-access-request label to new issue

### DIFF
--- a/lib/vtk/commands/socks/setup.rb
+++ b/lib/vtk/commands/socks/setup.rb
@@ -88,7 +88,7 @@ module Vtk
 
         def access_request_template_url
           'https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?' \
-            'assignees=&labels=external-request%2C+operations&template=Environment-Access-Request-Template.md&' \
+            'assignees=&labels=external-request%2C+operations%2C+ops-access-request&template=Environment-Access-Request-Template.md&' \
             'title=Access+for+%5Bindividual%5D'
         end
 

--- a/lib/vtk/commands/socks/setup.rb
+++ b/lib/vtk/commands/socks/setup.rb
@@ -88,8 +88,8 @@ module Vtk
 
         def access_request_template_url
           'https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?' \
-            'assignees=&labels=external-request%2C+operations%2C+ops-access-request&template=Environment-Access-Request-Template.md&' \
-            'title=Access+for+%5Bindividual%5D'
+            'assignees=&labels=external-request%2C+operations%2C+ops-access-request&' \
+            'template=Environment-Access-Request-Template.md&title=Access+for+%5Bindividual%5D'
         end
 
         def copy_and_open_gh


### PR DESCRIPTION
Noticed that the `ops-access-request` label was missing when creating the access request issue. When creating a new issue using [the actual issue template](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new/choose), this label is there.