### PR TITLE
Case insensitively check for Microsoft in /proc/version

### DIFF
--- a/lib/vtk/commands/socks/setup.rb
+++ b/lib/vtk/commands/socks/setup.rb
@@ -263,7 +263,7 @@ module Vtk
           return false unless ssh_config_exists?
 
           ssh_config_local = File.readlines ssh_config_path
-          ssh_config_local.grep(/UseKeychain yes/).size.positive?
+          ssh_config_local.grep(/UseKeychain yes/).any?
         end
 
         def ssh_agent_add
@@ -491,7 +491,7 @@ module Vtk
         end
 
         def wsl?
-          @wsl ||= File.exist?('/proc/version') && File.open('/proc/version').grep(/Microsoft/).size.positive?
+          @wsl ||= File.exist?('/proc/version') && File.open('/proc/version').grep(/Microsoft/i).any?
         end
 
         def ubuntu_like?

--- a/lib/vtk/version.rb
+++ b/lib/vtk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Vtk
-  VERSION = '0.9.1'
+  VERSION = '0.9.2'
 end


### PR DESCRIPTION
In particularly old versions of WSL, the word "Microsoft" is not capitalized in /proc/version as discovered by Jeremy Britt.