### PR TITLE
Update vtk.gemspec

### DIFF
--- a/vtk.gemspec
+++ b/vtk.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['eric.boehs@oddball.io', 'lindsey.hattamer@oddball.io', 'travis.hilton@oddball.io']
 
   spec.summary       = 'A CLI for the platform'
-  spec.description   = 'This is a platform CLI tool for VFS developer usage.'
+  spec.description   = 'The purpose of this gem is to allow engineers to quickly begin developing on VA.gov.'
   spec.homepage      = 'https://github.com/department-of-veterans-affairs/vtk'
   spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
 


### PR DESCRIPTION
[the description of the gem on rubygems](https://rubygems.org/gems/vtk) uses acronyms without context