### PR TITLE
Update SOCKS request url

### DIFF
--- a/lib/vtk/commands/socks/setup.rb
+++ b/lib/vtk/commands/socks/setup.rb
@@ -120,7 +120,7 @@ module Vtk
         def access_request_template_url
           'https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?' \
             'assignees=&labels=external-request%2C+operations%2C+ops-access-request&' \
-            'template=Environment-Access-Request-Template.yml&title=Access+for+%5Bindividual%5D'
+            'template=socks-access-request.yml&title=Access+for+%5Bindividual%5D'
         end
 
         def copy_and_open_gh


### PR DESCRIPTION
In https://github.com/department-of-veterans-affairs/va.gov-team/issues/31272, we will split the [Environment Access Request](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/.github/ISSUE_TEMPLATE/Environment-Access-Request-Template.yml) into two separate requests: a SOCKS proxy access request and an AWS access request. 

Once https://github.com/department-of-veterans-affairs/va.gov-team/pull/38713 merges, this PR can be merged.

_Note: I will also change the link to the access request on the Platform website. I have a draft of those changes here:_
https://vfs.atlassian.net/wiki/spaces/PWD/pages/2129788994/RT-Internal+tools+access+via+SOCKS+proxy
_I changed the_ Additional access for developers _section as well. The draft for those changes are here:_
https://vfs.atlassian.net/wiki/spaces/PWD/pages/2129788946/RT-Request+access+to+tools