### PR TITLE
Bump version to 0.9.4

### DIFF
--- a/lib/vtk/commands/socks/setup.rb
+++ b/lib/vtk/commands/socks/setup.rb
@@ -120,7 +120,7 @@ module Vtk
         def access_request_template_url
           'https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?' \
             'assignees=&labels=external-request%2C+operations%2C+ops-access-request&' \
-            'template=socks-access-request.yml&title=Access+for+%5Bindividual%5D'
+            'template=socks-access-request.yml&title=SOCKS+access+for+%5Bindividual%5D'
         end
 
         def copy_and_open_gh

--- a/lib/vtk/version.rb
+++ b/lib/vtk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Vtk
-  VERSION = '0.9.3'
+  VERSION = '0.9.4'
 end


### PR DESCRIPTION
After I merged https://github.com/department-of-veterans-affairs/vtk/pull/29, I did not bump the version per the instructions on the readme. I realized this after a few people opened blank access requests because `vtk` was sending them to the old URL:
https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=&labels=external-request%2C+operations%2C+ops-access-request&template=Environment-Access-Request-Template.yml&title=Access+for+%5Bindividual%5D

This PR fixes that and fixes the title of the SOCKS request. 