### PR TITLE
Add sudo to proxy setup command for MacOS.

### DIFF
--- a/lib/vtk/commands/socks/setup.rb
+++ b/lib/vtk/commands/socks/setup.rb
@@ -450,7 +450,7 @@ module Vtk
 
           log 'Configuring system proxy to use SOCKS tunnel...' do
             network_interfaces.map do |network_interface|
-              system %(networksetup -setautoproxyurl "#{network_interface}" "#{PROXY_URL}")
+              system %(sudo networksetup -setautoproxyurl "#{network_interface}" "#{PROXY_URL}")
             end.all?
           end
         end


### PR DESCRIPTION
This ensures that it works on devices configured to require a password when changing system-wide configuration.