### PR TITLE
Add SBOM generation workflow

### DIFF
--- a/.github/workflows/library-sbom.yml
+++ b/.github/workflows/library-sbom.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - 'Gemfile'
       - '*.gemspec'
-  pull_request:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/library-sbom.yml
+++ b/.github/workflows/library-sbom.yml
@@ -1,0 +1,21 @@
+name: Library SBOM Generation
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'Gemfile'
+      - '*.gemspec'
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  generate-sbom:
+    uses: department-of-veterans-affairs/vsp-github-actions/.github/workflows/library-sbom-generation.yml@main
+    with:
+      artifact_name: sbom
+      output_bucket: s3://vagov-infra-sbom-bucket/software/vtk


### PR DESCRIPTION
## Summary

Adds automated SBOM (Software Bill of Materials) generation using Trivy.

- Generates SBOM when Gemfile or gemspec changes on master
- Uploads to S3 bucket for Platform Security/CSOC
- Can be manually triggered via workflow_dispatch

## Related Issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/129925