### PR TITLE
fix(scan): match renamed compromised packages header

### DIFF
--- a/scripts/shai-hulud-repo-check.ps1
+++ b/scripts/shai-hulud-repo-check.ps1
@@ -91,7 +91,7 @@ $CacheDir = Join-Path $env:LOCALAPPDATA "vtk"
 $CacheFile = Join-Path $CacheDir "compromised-packages.txt"
 $CacheTTL = 86400  # 24 hours in seconds
 $MinExpectedPackages = 500
-$ExpectedHeader = "Shai-Hulud NPM Supply Chain Attack"
+$ExpectedHeader = "Shai-Hulud.*Supply Chain Attack"
 $PlaybookUrl = "https://department-of-veterans-affairs.github.io/eert/shai-hulud-dev-machine-cleanup-playbook"
 
 # Resolve path
@@ -151,7 +151,7 @@ function Test-PackageListValid {
     param([string]$Content)
 
     # Check for expected header
-    if ($Content -notmatch [regex]::Escape($ExpectedHeader)) {
+    if ($Content -notmatch $ExpectedHeader) {
         Write-Warning "Downloaded file missing expected header - possible MITM or corrupted file"
         return $false
     }

--- a/scripts/shai-hulud-repo-check.sh
+++ b/scripts/shai-hulud-repo-check.sh
@@ -50,7 +50,7 @@ CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/vtk"
 CACHE_FILE="$CACHE_DIR/compromised-packages.txt"
 CACHE_TTL=86400  # 24 hours
 MIN_EXPECTED_PACKAGES=500
-EXPECTED_HEADER="Shai-Hulud NPM Supply Chain Attack"
+EXPECTED_HEADER="Shai-Hulud.*Supply Chain Attack"
 PLAYBOOK_URL="https://department-of-veterans-affairs.github.io/eert/shai-hulud-dev-machine-cleanup-playbook"
 
 # Parse arguments
@@ -172,7 +172,7 @@ validate_package_list() {
   local content="$1"
 
   # Check for expected header
-  if ! echo "$content" | grep -q "$EXPECTED_HEADER"; then
+  if ! echo "$content" | grep -Eq "$EXPECTED_HEADER"; then
     echo "Downloaded file missing expected header - possible MITM or corrupted file" >&2
     return 1
   fi


### PR DESCRIPTION
## Summary
- Upstream `Cobenian/shai-hulud-detect/compromised-packages.txt` header was renamed from `Shai-Hulud NPM Supply Chain Attack` to `Shai-Hulud Supply Chain Attack - Compromised Packages List`, breaking `vtk scan repo` with a false `possible MITM or corrupted file` error
- Switch the bash and PowerShell scripts to a regex match (`Shai-Hulud.*Supply Chain Attack`) so both old and new wordings pass, while still rejecting unrelated or tampered files
- Reported by @cachelina — thanks Catalina!

## Test plan
- [x] Clear cache and run `bash scripts/shai-hulud-repo-check.sh --refresh /tmp` → cached 2,123 packages, status CLEAN
- [ ] Confirm `vtk scan repo` works against a real repo with a lockfile
- [ ] Spot-check PowerShell path on Windows (regex `-notmatch` is built-in, no escape needed)